### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Tested with ROS Melodic and ubuntu 18.04.
 and add at the end the following line. Replace PATH by the folder where you cloned ORB_SLAM3:
 
   ```
-  export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:PATH/ORB_SLAM3/Examples/ROS
+  export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:PATH/ORB_SLAM3/Examples/ROS/ORB_SLAM3
   ```
   
 2. Execute `build_ros.sh` script:


### PR DESCRIPTION
Fix something wrong with ROS_PACKAGE_PATH. It should be Examples/ROS/ORB_SLAM3 rather than Examples/ROS, right?